### PR TITLE
Fixed missing conditional in action-value fn def

### DIFF
--- a/slides/02/02.md
+++ b/slides/02/02.md
@@ -45,7 +45,7 @@ $$v_π(s) ≝ 𝔼_π\left[G_t \middle| S_t = s\right] = 𝔼_π\left[∑\nolimi
 
 ~~~
 An _action-value function_ for a policy $π$ is defined analogously as
-$$q_π(s, a) ≝ 𝔼_π\left[G_t \middle| S_t = s, A_t = a\right] = 𝔼_π\left[∑\nolimits_{k=0}^∞ γ^k R_{t+k+1} \middle| S_t=s\right].$$
+$$q_π(s, a) ≝ 𝔼_π\left[G_t \middle| S_t = s, A_t = a\right] = 𝔼_π\left[∑\nolimits_{k=0}^∞ γ^k R_{t+k+1} \middle| S_t=s, A_t = a\right].$$
 
 ~~~
 Evidently,


### PR DESCRIPTION
There is a missing conditional action in the second definition of action-value function according to the RL book (def. 3.13).