### PR TITLE
Fix more PAAC typos

### DIFF
--- a/labs/08/paac.py
+++ b/labs/08/paac.py
@@ -83,11 +83,11 @@ if __name__ == "__main__":
         for _ in range(args.evaluate_each):
             # TODO: Choose actions using network.predict_actions
 
-            # TODO: Perform steps by env.parallel_steps
+            # TODO: Perform steps by env.parallel_step
 
             # TODO: Compute return estimates by
             # - extracting next_states from steps
-            # - computing value function approximatin in next_states
+            # - computing value function approximation in next_states
             # - estimating returns by reward + (0 if done else args.gamma * next_state_value)
 
             # TODO: Train network using current states, chosen actions and estimated returns

--- a/labs/08/paac_continuous.py
+++ b/labs/08/paac_continuous.py
@@ -40,7 +40,7 @@ class Network:
             # TODO: Create `action_distribution` using tf.distributions.Normal
             # and computed `self.mus` and `self.sds`.
 
-            # TODO(reinforce_with_baseline): Compute `self.values`, starting with self.states and
+            # TODO(reinforce_with_baseline): Compute `self.values`, starting with `states` and
             # - add a fully connected layer of size args.hidden_layer and ReLU activation
             # - add a fully connected layer with 1 output and no activation
             # - modify the result to have shape `[batch_size]` (you can use for example `[:, 0]`)
@@ -107,11 +107,11 @@ if __name__ == "__main__":
             # using np.random.normal to sample action and np.clip
             # to clip it using action_lows and action_highs,
 
-            # TODO: Perform steps by env.parallel_steps
+            # TODO: Perform steps by env.parallel_step
 
             # TODO: Compute return estimates by
             # - extracting next_states from steps
-            # - computing value function approximatin in next_states
+            # - computing value function approximation in next_states
             # - estimating returns by reward + (0 if done else args.gamma * next_state_value)
 
             # TODO: Train network using current states, chosen actions and estimated returns


### PR DESCRIPTION
- "approximatin"
- instead of `self.states` we should actually use `states`
- `env.parallel_step` not `steps`