### PR TITLE
Fix SGD update rules

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -329,7 +329,7 @@ The functional approximation (i.e., the weight vector $→w$) is usually optimiz
 using gradient methods, for example as
 $$\begin{aligned}
   →w_{t+1} &← →w_t - \frac{1}{2} α ∇ \left[v_π(S_t) - v̂(S_t, →w_t)\right]^2\\
-           &← →w_t - α\left[v_π(S_t) - v̂(S_t, →w_t)\right] ∇ v̂(S_t, →w_t).\\
+           &← →w_t + α\left[v_π(S_t) - v̂(S_t, →w_t)\right] ∇ v̂(S_t, →w_t).\\
 \end{aligned}$$
 
 As usual, the $v_π(S_t)$ is estimated by a suitable sample. For example in Monte
@@ -352,7 +352,7 @@ as $→w$. It is sometimes called a _feature vector_.
 
 ~~~
 The SGD update rule then becomes
-$$→w_{t+1} ← →w_t - α\left[v_π(S_t) - v̂(→x(S_t), →w_t)\right] →x(S_t).$$
+$$→w_{t+1} ← →w_t + α\left[v_π(S_t) - v̂(→x(S_t), →w_t)\right] →x(S_t).$$
 
 ---
 # State Aggregation


### PR DESCRIPTION
I think there was a mistake, since ∇ (- v̂(S_t, →w_t)) = - ∇ v̂(S_t, →w_t). The minus sign did not appear in the rule. Also it is in the RL book this way.