### PR TITLE
Change '==' to '=' in lecture 01

### DIFF
--- a/slides/01/01.md
+++ b/slides/01/01.md
@@ -290,7 +290,7 @@ initial policy.
 
 ~~~
 Using SGD and MLE loss, we can derive the following algorithm:
-$$H_{t+1}(a) ← H_t(a) + αR_t([a == A_t] - π(a)).$$
+$$H_{t+1}(a) ← H_t(a) + αR_t([a = A_t] - π(a)).$$
 
 ---
 # Gradient Bandit Algorithms


### PR DESCRIPTION
Since the update rule uses '←' for assignment and not '=', I assume '==' was a typo and we can use '=' for equality