### PR TITLE
Fix typo in author name in lecture 08

### DIFF
--- a/slides/08/08.md
+++ b/slides/08/08.md
@@ -117,7 +117,7 @@ section: PAAC
 
 An alternative to independent workers is to train in a synchronous and
 centralized way by having the workes to only generate episodes. Such approach
-was described in May 2017 by Celemente et al., who named their agent
+was described in May 2017 by Clemente et al., who named their agent
 _parallel advantage actor-critic_ (PAAC).
 
 ![w=70%,h=center](paac_framework.pdf)


### PR DESCRIPTION
Celemente -> Clemente

Also, the sentence "All nonlinearities are ReLU" is cropped for me as "All nonlinearities are", which is true yet not very useful. (Firefox 64.0.2, macOS Mojave)