### PR TITLE
Fix index of V in N-step TD in lecture 04

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -193,7 +193,7 @@ with $G_{t:t+n} ≝ G_t$ if $t+n ≥ T$.
 # $n$-step Methods
 
 A natural update rule is
-$$V_{t+n}(S_t) ≝ V_{t+n-1}(S_t) + α\left[G_{t:t+n} - V_{t+n-1}(S_t)\right].$$
+$$V_{t+n}(S_t) ≝ V_{t+n}(S_t) + α\left[G_{t:t+n} - V_{t+n}(S_t)\right].$$
 
 ~~~
 ![w=55%,h=center](nstep_td_prediction.pdf)


### PR DESCRIPTION
According to the penultimate line of the pseudocode, we update V(S_t) <- V(S_t) + alpha * (G - V(S_t)); this doesn't match the current slides.