### PR TITLE
Fix some typos and add return recapitulation slide.

### DIFF
--- a/slides/09/09.md
+++ b/slides/09/09.md
@@ -44,9 +44,9 @@ $$ρ_t ≝ \frac{π(A_t | S_t)}{b(A_t | S_t)},~~~ρ_{t:t+n} ≝ ∏_{i=0}^n ρ_{
 
 ~~~
 First note that
-$$𝔼_{A_t ∼ b} \big[ρ_t\big] = ∑_{A_t} b(A_t | S_t) \frac{π(A_t | S_t)}{b(A_t | S_t)},$$
+$$𝔼_{A_t ∼ b} \big[ρ_t\big] = ∑_{A_t} b(A_t | S_t) \frac{π(A_t | S_t)}{b(A_t | S_t)} = 1,$$
 which can be extended to
-$$𝔼_μ \big[ρ_{t:t+n}\big] = 1.$$
+$$𝔼_b \big[ρ_{t:t+n}\big] = 1.$$
 
 ---
 # Off-policy Correction Using Control Varietes
@@ -144,7 +144,7 @@ errors
 
 $$\begin{aligned}
   G_{t:t+n}^λ - V(S_t)
-  & = (1 - λ) \big(R_{t+1} + γV(S_{t+1})\big) + λ (R_{t+1} + γ G_{t+1:t+n}^λ) \\
+  & = (1 - λ) \big(R_{t+1} + γV(S_{t+1})\big) + λ (R_{t+1} + γ G_{t+1:t+n}^λ) - V(S_t) \\
   & = R_{t+1} + γV(S_{t+1}) - V(S_t) + λ γ \big(G_{t+1:t+n}^λ - V(S_{t+1})\big),
 \end{aligned}$$
 obtaining an analogous estimate $G_{t:t+n}^λ = V(S_t) + ∑\nolimits_{i=0}^{n-1} γ^i λ^i δ_{t+i}.$
@@ -194,7 +194,21 @@ backward view.
 The eligibility traces can be combined with control varietes, obtaining (DETAILS
 TO BE ADDED LATER)
 $$G_{t:t+n}^\mathrm{λ,CV}
-  = ∑\nolimits_{i=0}^{n-1} γ^i λ^i ρ_{t:t+i} δ_{t+i}.$$
+  = V(S_t) + ∑\nolimits_{i=0}^{n-1} γ^i λ^i ρ_{t:t+i} δ_{t+i}.$$
+
+---
+# Return Recapitulation
+
+So far we have see following $n$-step return definitions:
+
+| Recursive definition                                                                          | Formulation with TD errors                                          |
+|-----------------------------------------------------------------------------------------------|---------------------------------------------------------------------|
+| $G_{t:t+n} ≝ R_{t+1} + γ G_{t+1:t+n}$                                                         | $V(S_t) + ∑_{i=0}^{n-1} γ^i δ_{t+i}$                                |
+| $G_{t:t+n}^\mathrm{IS} ≝ ρ_t \big(R_{t+1} + γ G_{t+1:t+n}^\mathrm{IS}\big)$                   |                                                                     |
+| $G_{t:t+n}^\mathrm{CV} ≝ ρ_t \big(R_{t+1} + γ G_{t+1:t+n}^\mathrm{CV}\big) + (1 - ρ_t)V(S_t)$ | $V(S_t) + ∑\nolimits_{i=0}^{n-1} γ^i ρ_{t:t+i} δ_{t+i}$             |
+| $G_{t:t+n}^λ ≝ (1 - λ) G_{t:t+1} + λ (R_{t+1} + γ G_{t+1:t+n}^λ)$                             | $V(S_t) + ∑\nolimits_{i=0}^{n-1} γ^i λ^i δ_{t+i}$                   |
+| $G_{t:t+n}^{λ_i} ≝ (1 - λ_{t+1}) G_{t:t+1} + λ_{t+1} (R_{t+1} + γ G_{t+1:t+n}^λ)$             | $V(S_t) + ∑_{i=0}^{n-1} γ^i \left(∏_{j=1}^i λ_{t+j}\right) δ_{t+i}$ |
+| $G_{t:t+n}^\mathrm{λ,CV} ≝ ???$                                                               | $V(S_t) + ∑\nolimits_{i=0}^{n-1} γ^i λ^i ρ_{t:t+i} δ_{t+i}$         |
 
 ---
 section: V-trace
@@ -203,7 +217,7 @@ section: V-trace
 V-trace is a modified version of $n$-step return with off-policy correction,
 defined in the Feb 2018 IMPALA paper as (using the notation from the paper):
 
-$$v_s ≝ V(S_s) + ∑_{t=s}^{s+n-1} γ^{t-s} \left(∏\nolimits_{i=s}^{t-1} c_i\right) δ_t V,$$
+$$G_{s:s+n}^\mathrm{\text{V-trace}} = v_s ≝ V(S_s) + ∑_{t=s}^{s+n-1} γ^{t-s} \left(∏\nolimits_{i=s}^{t-1} c_i\right) δ_t V,$$
 ~~~
 where $δ_t V$ is the temporal difference for V
 $$δ_t V ≝ ρ_t \big(R_{t+1} + γV(s_{t+1}) - V(s_t)\big),$$
@@ -229,7 +243,7 @@ Note that the truncated IS weights $ρ_t$ and $c_i$ play different roles:
 ~~~
   Concretely, it can be proven that the fixed point of the value function
   $v_s$ is the policy
-  $$π_ρ̄(a|x) ∝ \min\big(ρ̄b(a|s), π(a|s)\big).$$
+  $$π_ρ̄(a|s) ∝ \min\big(ρ̄b(a|s), π(a|s)\big).$$
 ~~~
 - The $c_i$ impacts the speed of convergence (the contraction rate of the
   Bellman operator), not the sought policy. Because a product of the $c_i$


### PR DESCRIPTION
I believe that the summary slide with all return definitions is
convenient as a brief recapitulation. Also I suggest rewrite the V-trace
part to use the notation used in the first part as it is quite schizophrenic.