### PR TITLE
A few changes in lecture 7 slides

### DIFF
--- a/slides/07/07.md
+++ b/slides/07/07.md
@@ -106,7 +106,7 @@ add the entropy penalty).
 
   action_dist = tfp.distributions.Normal(mus, sds)
 
-  # Loss computed as - log π(a|s) - entropy_regularization
+  # Loss computed as - log π(a|s) * returns - entropy_regularization
   loss = - action_dist.log_prob(actions) * returns \
          - args.entropy_regularization * action_dist.entropy()
 ```

--- a/slides/07/07.md
+++ b/slides/07/07.md
@@ -194,7 +194,7 @@ $\displaystyle \phantom{∇_→θ v_π(s)} = ∇_→θ π(s; →θ) ∇_a q_π(s
 
 ~~~
 We finish the proof as in the gradient theorem by continually expanding $∇_→θ v_π(s')$, getting
-$∇_→θ v_π(s) = ∫_{s'} ∑_{k=0}^∞ γ^k P(s → s'\textrm{~in~}k\textrm{~steps~}|π) \big[∇_→θ π(s; →θ) ∇_a q_π(s, a)\big|_{a=π(s;→θ)}\big] \d s'$
+$∇_→θ v_π(s) = ∫_{s'} ∑_{k=0}^∞ γ^k P(s → s'\textrm{~in~}k\textrm{~steps~}|π) \big[∇_→θ π(s'; →θ) ∇_a q_π(s', a)\big|_{a=π(s';→θ)}\big] \d s'$
 ~~~
 and then $∇_→θ J(→θ) = 𝔼_{s ∼ h} ∇_→θ v_π(s) ∝ 𝔼_{s∼μ(s)} \big[∇_→θ π(s; →θ) ∇_a q_π(s, a)\big|_{a=π(s;→θ)}\big]$.
 

--- a/slides/07/07.md
+++ b/slides/07/07.md
@@ -150,7 +150,7 @@ Assume that the policy $π(s; →θ)$ is deterministic and computes
 an action $a∈ℝ$. Further, assume the reward $r(s, a)$ is actually
 a deterministic function of the given state-action pair.
 Then, under several assumptions about continuousness, the following holds:
-$$∇_→θ J(→θ) ∝ 𝔼_{s∼μ(s)} \Big[∇_→θ π(s; →θ) ∇_a q_π(s, a)\big|_{a=π(s;→θ)}\Big].$$
+$$∇_→θ J(→θ) ∝ 𝔼_{s ∼ μ} \Big[∇_→θ π(s; →θ) ∇_a q_π(s, a)\big|_{a=π(s;→θ)}\Big].$$
 
 The theorem was first proven in the paper Deterministic Policy Gradient Algorithms
 by David Silver et al in 2014.
@@ -196,7 +196,7 @@ $\displaystyle \phantom{∇_→θ v_π(s)} = ∇_→θ π(s; →θ) ∇_a q_π(s
 We finish the proof as in the gradient theorem by continually expanding $∇_→θ v_π(s')$, getting
 $∇_→θ v_π(s) = ∫_{s'} ∑_{k=0}^∞ γ^k P(s → s'\textrm{~in~}k\textrm{~steps~}|π) \big[∇_→θ π(s'; →θ) ∇_a q_π(s', a)\big|_{a=π(s';→θ)}\big] \d s'$
 ~~~
-and then $∇_→θ J(→θ) = 𝔼_{s ∼ h} ∇_→θ v_π(s) ∝ 𝔼_{s∼μ(s)} \big[∇_→θ π(s; →θ) ∇_a q_π(s, a)\big|_{a=π(s;→θ)}\big]$.
+and then $∇_→θ J(→θ) = 𝔼_{s ∼ h} ∇_→θ v_π(s) ∝ 𝔼_{s ∼ μ} \big[∇_→θ π(s; →θ) ∇_a q_π(s, a)\big|_{a=π(s;→θ)}\big]$.
 
 ---
 section: DDPG


### PR DESCRIPTION
Hi, I made these changes:
*  I think it should be `s'` instead of `s` in the DPG proof 
![Screenshot 2021-01-14 185815](https://user-images.githubusercontent.com/36577287/104630081-a1891500-569a-11eb-9888-5307cf370e74.png)
*  I added `* returns` to the comment
![Screenshot 2021-01-14 190126](https://user-images.githubusercontent.com/36577287/104630373-f6c52680-569a-11eb-8bd8-c644bb21b547.png)
*  changed the notation to `s ∼ μ`, which is consistent with `s ~ h` and the policy gradient text
