### PR TITLE
Keep two empty lines after imports

### DIFF
--- a/labs/01/monte_carlo.py
+++ b/labs/01/monte_carlo.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import wrappers
 
+
 parser = argparse.ArgumentParser()
 # These arguments will be set appropriately by ReCodEx, even if you change them.
 parser.add_argument("--recodex", default=False, action="store_true", help="Running in ReCodEx")


### PR DESCRIPTION
I have noticed this is the only Python file that has only one empty space after imports.