### PR TITLE
Add a missing word

### DIFF
--- a/slides/04/04.md
+++ b/slides/04/04.md
@@ -39,8 +39,8 @@ either as $v(s)$ or as $q(s, a)$.
 section: Function Approximation
 # Function Approximation
 
-We will approximate value function $v$ and/or state-value function $q$,
-selecting it from a family of functions parametrized by a weight vector $→w ∈ ℝ^d$.
+We will approximate value function $v$ and/or state-value function $q$
+by selecting it from a family of functions parametrized by a weight vector $→w ∈ ℝ^d$.
 
 ~~~
 We denote the approximations as


### PR DESCRIPTION
Add `by` to the second slide. I removed the comma because _I_ think it should not be there now that I added the missing word, but I am not completely sure.