### PR TITLE
Correct a typo in `q_learning_tiles.md`

### DIFF
--- a/tasks/q_learning_tiles.md
+++ b/tasks/q_learning_tiles.md
@@ -7,7 +7,7 @@ Improve the `q_learning` task performance on the
 using linear function approximation with tile coding.
 Your goal is to reach an average reward of -110 during 100 evaluation episodes.
 
-The environment methods are described in the `q_learning` assignments, with
+The environment methods are described in the `q_learning` assignment, with
 the following changes:
 - The `state` returned by the `env.step` method is a _list_ containing weight
   indices of the current state (i.e., the feature vector of the state consists


### PR DESCRIPTION
I believe, there was only one assignment.

Btw. the environment methods and properties are described in the second assignment `monte_carlo` but I did not change it, as the `q_learning` assignment points to the right spot.