### PR TITLE
Simplify and improve pytorch code for QNetwork

### DIFF
--- a/labs/04/q_network.torch.py
+++ b/labs/04/q_network.torch.py
@@ -84,11 +84,7 @@ class Network:
     # If you want to use target network, the following method copies weights from
     # a given Network to the current one.
     def copy_weights_from(self, other: Network) -> None:
-        params = dict(self._model.named_parameters())
-        params_other = dict(other._model.named_parameters())
-        with torch.no_grad():
-            for name, value in params_other.items():
-                params[name].data.copy_(value.data)
+        self._model.load_state_dict(other._model.state_dict())
 
 
 def main(env: wrappers.EvaluationEnv, args: argparse.Namespace) -> None:
@@ -115,7 +111,7 @@ def main(env: wrappers.EvaluationEnv, args: argparse.Namespace) -> None:
         while not done:
             # TODO: Choose an action.
             # You can compute the q_values of a given state by
-            #   q_values = network.predict([state])[0]
+            #   q_values = network.predict(state.reshape(1, -1))[0]
             action = ...
 
             next_state, reward, terminated, truncated, _ = env.step(action)


### PR DESCRIPTION
Regarding the copying of weights. You probably want to have both the policy and target network in the same `Network` class as it's needed to calculate the target Q values for computing the loss. So the `copy_weights_from` should rather look like:

```python
def update_target_net(self):
    # torch.no_grad is not required here
    self._target_net.load_state_dict(self._model.state_dict())
```

or we could provide a method for doing the soft (Polyak) update right away

```python
def soft_update_weights(self, tau):
    with torch.no_grad():
        for param, target_param in zip(self._model.parameters(), self._target_net.parameters()):
            target_param.data.mul_(1 - tau)
            torch.add(target_param.data, param.data, alpha=tau, out=target_param.data)
```