### PR TITLE
Make explanation of DDQN target update clearer

### DIFF
--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -88,7 +88,7 @@ Important improvements:
 ~~~
 - separate **target network** $→θ̄$: to prevent instabilities, a separate _target
   network_ is used to estimate one-step returns. The weights are not trained,
-  but copied from the trained network once in a while;
+  but copied from the trained network after a set number of gradient updates;
 ~~~
 - reward clipping: because rewards have wildly different scale in different
   games, all positive rewards are replaced by $+1$ and negative by $-1$;


### PR DESCRIPTION
After a discussion with a classmate who was copying the target weights after N epochs and not after N gradient updates I deemed this changes useful :)