### PR TITLE
Fix expression for calculating replay priorities

### DIFF
--- a/slides/05/05.md
+++ b/slides/05/05.md
@@ -188,7 +188,7 @@ section: PriRep
 Instead of sampling the transitions uniformly from the replay buffer,
 we instead prefer those with a large TD error. Therefore, we sample transitions
 according to their probability
-$$p_t ∝ \Big|r + γ \max_{a'} Q(s', a'; θ̄) - Q(s, a; θ)\Big|^ω,$$
+$$p_t ∝ \Big|r + γ Q(s', \argmax_{a'}Q(s', a'; θ); θ̄) - Q(s, a; θ)\Big|^ω,$$
 ~~~
 where $ω$ controls the shape of the distribution (which is uniform for $ω=0$
 and corresponds to TD error for $ω=1$).


### PR DESCRIPTION
Not sure if it really matters to use the standard TD error for the probabilities, but when combining PER with DDQN this is easier to implement and is also consistent with the algorithm pseudocode on slide 17.