### PR TITLE
[08/walker.torch] Map model to the correct device when loading

### DIFF
--- a/labs/08/walker.torch.py
+++ b/labs/08/walker.torch.py
@@ -121,7 +121,7 @@ class Network:
         torch.save(self._actor.state_dict(), path)
 
     def load_actor(self, path: str, env: wrappers.EvaluationEnv):
-        self._actor.load_state_dict(torch.load(path))
+        self._actor.load_state_dict(torch.load(path, map_location=self._device))
 
     @wrappers.typed_np_function(np.float32, np.float32, np.float32)
     def train(self, states: np.ndarray, actions: np.ndarray, returns: np.ndarray) -> None:


### PR DESCRIPTION
When loading a model trained on GPU to CPU we need to map it to the correct device. Otherwise we get a `RuntimeError`:

```
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.
```