### PR TITLE
[08/walker.torch] Clarify the description of distribution transforms

### DIFF
--- a/labs/08/walker.torch.py
+++ b/labs/08/walker.torch.py
@@ -62,14 +62,14 @@ class Network:
                 # - We then bijectively modify the distribution so that the actions are
                 #   in the given range. Luckily, `torch.distributions.transforms` offers
                 #   classes that can transform a distribution.
-                #   - first run
-                #       torch.distributions.transforms.TanhTransform()
-                #     to squash the actions to [-1, 1] range,
-                #   - then run
-                #       torch.distributions.transforms.AffineTransform(loc, scale)
-                #     to scale the action ranges to [low, high].
-                #   - To compose these transformations, use
-                #       torch.distributions.transforms.ComposeTransform([t1, t2], cache_size=1)
+                #   For that use `torch.distributions.TransformedDistribution` and apply the
+                #   following transformations:
+                #   - `torch.distributions.transforms.TanhTransform()`
+                #     - to squash the actions to [-1, 1] range,
+                #   - `torch.distributions.transforms.AffineTransform(loc, scale)`
+                #     - to scale the action ranges to [low, high].
+                #   - To compose these transformations, you can use
+                #       `torch.distributions.transforms.ComposeTransform([t1, t2], cache_size=1)`
                 #     with `cache_size=1` parameter for numerical stability.
                 # - Sample the actions by a `rsample()` call (`sample()` is not differentiable).
                 # - Then, compute the log-probabilities of the sampled actions by using `log_prob()`


### PR DESCRIPTION
The description of how the transforms should be used was a bit confusing. We cannot directly apply the transforms to the distribution, instead we have to create a new `TransformedDistribution` with the list of transforms as argument. 

```python
transformed_dist = torch.distributions.TransformedDistribution(dist, [transforms])
```

This should help clarify that.

Also for performance reasons, we could move the `scale` and `loc` to the constructor and even instantiate the transforms there and only apply them during the forward pass.